### PR TITLE
Fixes to evaluator.ipynb 

### DIFF
--- a/notebooks/evaluator.ipynb
+++ b/notebooks/evaluator.ipynb
@@ -36,6 +36,7 @@
     "#On windows use  sys.path.append(module_path+\"\\\\src\\\\functionapp\")\n",
     "\n",
     "from ai_ocr.azure.openai_ops import load_image, get_size_of_base64_images\n",
+    "from ai_ocr.azure.images import extract_images_from_pdf\n"
     "from ai_ocr.model import Config\n",
     "from ai_ocr.chains import get_structured_data\n",
     "from ai_ocr.azure.doc_intelligence import get_ocr_results\n",


### PR DESCRIPTION
Adding import that was missing. 

There were some more changes that I had to make locally to make it run (but I made them in hacky way so don't include in the PR):
1. module_path approach didn't work (MacOS). I hardcoded the path to make it work locally 
sys.path.append("../azure-doc-extraction-gbb-ai/src/functionapp")
2. Config would not load. So I hardcoded values from the config
max_size = 20 * 1024 * 1024  # 20MB
imgs = imgs[:8]

In addition to that, I made an observation that extract_images_from_pdf transforms pdf into the image for the particular example "Invoice Sample.pdf". So it makes sense to pass this image into the model. But this transformation instead of extraction is very particular to the sample chosen. I used a couple of other pdfs and extract_images_from_pdf just extracts images (e.g logos). These images are mostly useless to the model and the model mostly uses the data coming from the Document Intelligence. So the expensive vision capable model might not be used to the full capacity. Do I understand it right? I can give examples/elaborate if needed.
